### PR TITLE
Switch to Django 2.2. bulk update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ key_fields = ('name', )
 ret = bulk_sync(
         new_models=new_models,
         filters=filters,
+        fields=['name', 'phone_number', ...],
         key_fields=key_fields)
 
 print("Results of bulk_sync: "
@@ -66,6 +67,7 @@ Combine bulk create, update, and delete.  Make the DB match a set of in-memory o
 - `key_fields`: Identifying attribute name(s) to match up `new_models` items with database rows.  If a foreign key is being used as a key field, be sure to pass the `fieldname_id` rather than the `fieldname`.
 - `filters`: Q() filters specifying the subset of the database to work in.
 - `batch_size`: passes through to Django `bulk_create.batch_size` and `bulk_update.batch_size`, and controls how many objects are created/updated per SQL query.
+- `fields`: a list of fields to update - passed through to Django's built in `buld_update` 
 
 `def bulk_compare(old_models, new_models, key_fields, ignore_fields=None):`
 Compare two sets of models by `key_fields`.
@@ -85,4 +87,4 @@ Compare two sets of models by `key_fields`.
 
 ## Frameworks Supported
 
-This library is tested using Python 3 against Django 1.11 and Django 2.2.
+This library is tested using Python 3 against Django 2.2.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-Django>=1.8
-django-bulk-update>2
+Django>=2.2


### PR DESCRIPTION
Not sure if this is wanted in the library - it's something we wanted to switch to though. Happy to keep our internal fork if it's not wanted.

Switch to using Django 2.2 `bulk_update`. It has an extra parameter `fields` over the previous `bulk_update` which is a list of fields to update. Added a nullable `fields` parameter for it. If null, it pulls out a list of fields from the model that aren't PKs and aren't editable (e.g `auto_add_now=True`). The latter assumption there may be questionable - it won't update `auto_now=True`  fields. 