### PR TITLE
fix: optional arg to avoid select_for_update issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django>=2.2
+dj-database-url==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="django-bulk-sync",
-    version="3.2.0",
+    version="3.2.1",
     description="Combine bulk add, update, and delete into a single call.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/models.py
+++ b/tests/models.py
@@ -17,7 +17,7 @@ class Employee(models.Model):
 
 class EmployeeDifferentPk(models.Model):
     employee_id = models.AutoField(primary_key=True)
-    
+
     age = models.IntegerField()
     name = models.CharField(max_length=140, blank=True, null=True)
 
@@ -25,3 +25,30 @@ class EmployeeDifferentPk(models.Model):
 
     def __str__(self):
         return "EmployeeDiffPk: {} age {} company {}".format(self.name, self.age, self.company_id)
+
+
+class EmployeeWithOffice(models.Model):
+    age = models.IntegerField()
+    name = models.CharField(max_length=140, blank=True, null=True)
+
+    company = models.ForeignKey(Company, models.CASCADE)
+
+    def __str__(self):
+        return "EmployeeWithOffice: {} age {} company {}".format(self.name, self.age, self.company_id)
+
+class Office(models.Model):
+    id = models.CharField(max_length=100, primary_key=True)
+    employees = models.ManyToManyField(
+        "EmployeeWithOffice", through="EmployeeOffice",
+    )
+
+class EmployeeOffice(models.Model):
+    office = models.ForeignKey(
+        "Office", null=False, on_delete=models.CASCADE
+    )
+    employee = models.ForeignKey(
+        "EmployeeWithOffice", null=True, on_delete=models.CASCADE
+    )
+
+    def __str__(self):
+        return "EmployeeOffice: {} employee {} office {}".format(self.employee.name, self.office.id)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -340,8 +340,9 @@ class BulkSyncTests(TestCase):
         self.assertEqual(0, ret["stats"]["deleted"])
         self.assertEqual(1, ret["stats"]["created"])
 
-        """ eos = o3.employees.all()
-        self.assertEqual(1, eos.count()) """
+        eos = o3.employees.all()
+        self.assertEqual(1, eos.count())
+        self.assertEqual(o3, e5.office_set.first())
 
 
 class BulkCompareTests(TestCase):


### PR DESCRIPTION
PostgreSQL doesn't support `SELECT FOR UPDATE` if there are nullable parts in the outer join side (`SELECT FOR UPDATE cannot be applied to the nullable side of an outer join`).
To avoid this issue, `select_for_update` has an `of` argument to exclude the nullable parts of the query. https://docs.djangoproject.com/en/4.0/ref/models/querysets/#select-for-update
https://github.com/django/django/blob/cb82ded4b26f514c11349c9d13287bb3fb9268c9/tests/select_for_update/tests.py#L416-L426