### PR TITLE
Force Order to Prevent Deadlocks

### DIFF
--- a/bulk_sync/__init__.py
+++ b/bulk_sync/__init__.py
@@ -79,7 +79,7 @@ def bulk_sync(
         objs = db_class.objects.all()
         if filters:
             objs = objs.filter(filters)
-        objs = objs.only("pk", *key_fields).select_for_update()
+        objs = objs.only("pk", *key_fields).select_for_update().order_by('pk')
 
         prep_functions = defaultdict(lambda: lambda x: x)
         prep_functions.update({


### PR DESCRIPTION
When using `select_for_update()`, it's really easy to get into a deadlock situation if you have any amount of concurrency. This PR explicitly orders the `select_for_update()` call which should prevent deadlocks.